### PR TITLE
Use virtual file system when checking CRC

### DIFF
--- a/src/cfdppy/filestore.py
+++ b/src/cfdppy/filestore.py
@@ -156,6 +156,7 @@ class HostFilestore(VirtualFilestore):
             _LOGGER.warning("File already exists")
             return FilestoreResponseStatusCode.CREATE_NOT_ALLOWED
         try:
+            file.parent.mkdir(parents=True, exist_ok=True)
             file_handle = open(file, "x")
             file_handle.close()
             return FilestoreResponseStatusCode.CREATE_SUCCESS

--- a/src/cfdppy/filestore.py
+++ b/src/cfdppy/filestore.py
@@ -15,7 +15,8 @@ FilestoreResult = FilestoreResponseStatusCode
 
 class VirtualFilestore(abc.ABC):
     @abc.abstractmethod
-    def read_data(self, file: Path, offset: Optional[int], read_len: int) -> bytes:
+    def read_data(self, file: Path, offset: Optional[int],
+                  read_len: Optional[int]) -> bytes:
         """This is not used as part of a filestore request, it is used to read a file, for example
         to send it"""
         raise NotImplementedError("Reading file not implemented in virtual filestore")

--- a/src/cfdppy/handler/__init__.py
+++ b/src/cfdppy/handler/__init__.py
@@ -1,5 +1,5 @@
 from spacepackets.seqcount import ProvidesSeqCount
-from cfdppy.mib import (
+from ..mib import (
     LocalEntityCfg,
     RemoteEntityCfgTable,
     RemoteEntityCfg,

--- a/src/cfdppy/handler/crc.py
+++ b/src/cfdppy/handler/crc.py
@@ -5,8 +5,8 @@ from typing import Optional
 from crcmod.predefined import PredefinedCrc
 
 from spacepackets.cfdp import ChecksumType, NULL_CHECKSUM_U32
-from cfdppy.filestore import VirtualFilestore
-from cfdppy.exceptions import ChecksumNotImplemented, SourceFileDoesNotExist
+from ..filestore import VirtualFilestore
+from ..exceptions import ChecksumNotImplemented, SourceFileDoesNotExist
 
 
 def calc_modular_checksum(file_path: Path) -> bytes:

--- a/src/cfdppy/handler/crc.py
+++ b/src/cfdppy/handler/crc.py
@@ -1,4 +1,5 @@
 import struct
+import io
 from pathlib import Path
 from typing import Optional
 
@@ -8,22 +9,6 @@ from spacepackets.cfdp import ChecksumType, NULL_CHECKSUM_U32
 from ..filestore import VirtualFilestore
 from ..exceptions import ChecksumNotImplemented, SourceFileDoesNotExist
 
-
-def calc_modular_checksum(file_path: Path) -> bytes:
-    """Calculates the modular checksum for a file in one go."""
-    checksum = 0
-
-    with open(file_path, "rb") as file:
-        while True:
-            data = file.read(4)
-            if not data:
-                break
-            checksum += int.from_bytes(
-                data.ljust(4, b"\0"), byteorder="big", signed=False
-            )
-
-    checksum %= 2**32
-    return struct.pack("!I", checksum)
 
 
 class CrcHelper:
@@ -57,7 +42,7 @@ class CrcHelper:
         if self.checksum_type == ChecksumType.NULL_CHECKSUM:
             return NULL_CHECKSUM_U32
         elif self.checksum_type == ChecksumType.MODULAR:
-            return calc_modular_checksum(file_path)
+            return self.calc_modular_checksum(file_path)
         crc_obj = self.generate_crc_calculator()
         if segment_len == 0:
             raise ValueError("Segment length can not be 0")
@@ -65,15 +50,32 @@ class CrcHelper:
             raise SourceFileDoesNotExist(file_path)
         current_offset = 0
         # Calculate the file CRC
-        with open(file_path, "rb") as file:
-            while current_offset < file_sz:
-                if current_offset + segment_len > file_sz:
-                    read_len = file_sz - current_offset
-                else:
-                    read_len = segment_len
-                if read_len > 0:
-                    crc_obj.update(
-                        self.vfs.read_from_opened_file(file, current_offset, read_len)
-                    )
-                current_offset += read_len
-            return crc_obj.digest()
+        file = io.BytesIO(self.vfs.read_data(file_path, None, None))
+        while current_offset < file_sz:
+            if current_offset + segment_len > file_sz:
+                read_len = file_sz - current_offset
+            else:
+                read_len = segment_len
+            if read_len > 0:
+                crc_obj.update(
+                    self.vfs.read_from_opened_file(file, current_offset, read_len)
+                )
+            current_offset += read_len
+        return crc_obj.digest()
+
+    def calc_modular_checksum(self, file_path: Path) -> bytes:
+        """Calculates the modular checksum for a file in one go."""
+        checksum = 0
+
+        file = io.BytesIO(self.vfs.read_data(file_path, None, None))
+        while True:
+            data = file.read(4)
+            if not data:
+                break
+            checksum += int.from_bytes(
+                data.ljust(4, b"\0"), byteorder="big", signed=False
+            )
+
+        checksum %= 2**32
+        return struct.pack("!I", checksum)
+

--- a/src/cfdppy/handler/dest.py
+++ b/src/cfdppy/handler/dest.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Deque, List, Optional, Tuple
 
-from cfdppy.defs import CfdpState
-from cfdppy.exceptions import (
+from ..defs import CfdpState
+from ..exceptions import (
     FsmNotCalledAfterPacketInsertion,
     InvalidDestinationId,
     InvalidPduDirection,
@@ -18,23 +18,23 @@ from cfdppy.exceptions import (
     PduIgnoredForDestReason,
     UnretrievedPdusToBeSent,
 )
-from cfdppy.handler.common import (
+from ..handler.common import (
     PacketDestination,
     _PositiveAckProcedureParams,
     get_packet_destination,
 )
-from cfdppy.handler.crc import CrcHelper
-from cfdppy.handler.defs import (
+from ..handler.crc import CrcHelper
+from ..handler.defs import (
     _FileParamsBase,
 )
-from cfdppy.mib import (
+from ..mib import (
     CheckTimerProvider,
     EntityType,
     LocalEntityCfg,
     RemoteEntityCfg,
     RemoteEntityCfgTable,
 )
-from cfdppy.user import (
+from ..user import (
     CfdpUserBase,
     FileSegmentRecvdParams,
     MetadataRecvParams,

--- a/src/cfdppy/handler/source.py
+++ b/src/cfdppy/handler/source.py
@@ -7,13 +7,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Deque, Optional, Tuple
 
-from cfdppy import (
+from .. import (
     CfdpUserBase,
     LocalEntityCfg,
     RemoteEntityCfg,
 )
-from cfdppy.defs import CfdpState
-from cfdppy.exceptions import (
+from ..defs import CfdpState
+from ..exceptions import (
     FsmNotCalledAfterPacketInsertion,
     InvalidDestinationId,
     InvalidNakPdu,
@@ -27,14 +27,14 @@ from cfdppy.exceptions import (
     SourceFileDoesNotExist,
     UnretrievedPdusToBeSent,
 )
-from cfdppy.handler.common import _PositiveAckProcedureParams
-from cfdppy.handler.crc import CrcHelper
-from cfdppy.handler.defs import (
+from ..handler.common import _PositiveAckProcedureParams
+from ..handler.crc import CrcHelper
+from ..handler.defs import (
     _FileParamsBase,
 )
-from cfdppy.mib import CheckTimerProvider, EntityType, RemoteEntityCfgTable
-from cfdppy.request import PutRequest
-from cfdppy.user import TransactionFinishedParams, TransactionParams
+from ..mib import CheckTimerProvider, EntityType, RemoteEntityCfgTable
+from ..request import PutRequest
+from ..user import TransactionFinishedParams, TransactionParams
 from spacepackets.cfdp import (
     NULL_CHECKSUM_U32,
     ChecksumType,

--- a/src/cfdppy/user.py
+++ b/src/cfdppy/user.py
@@ -8,7 +8,7 @@ from spacepackets.cfdp.tlv import MessageToUserTlv
 from spacepackets.cfdp.pdu.file_data import SegmentMetadata
 from spacepackets.cfdp.pdu.finished import FinishedParams
 from spacepackets.util import UnsignedByteField
-from cfdppy.filestore import VirtualFilestore, HostFilestore
+from .filestore import VirtualFilestore, HostFilestore
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Hi, I noticed the CRC file which verifies the downloaded file checksum does not use the file system provided in the user config.

This causes an issue for a file system which changes the root location of CFDP files (I created a file systems which handles all cfdp files in /tmp/cfdp/ to avoid polluting my executable dir for example).

I therefore edited the crc file to make use of this vfs.

All the tests have been run and passed successfully:
```
❯ python -m pytest
================================ test session starts =================================
platform linux -- Python 3.10.12, pytest-8.0.0, pluggy-1.4.0
rootdir: /home/alex/code/python/cfdppy/module
plugins: pyfakefs-5.3.5
collected 77 items

tests/test_checksum.py .                                                       [  1%]
tests/test_dest_handler_acked.py ...............                               [ 20%]
tests/test_dest_handler_naked.py ..............                                [ 38%]
tests/test_filestore.py ........                                               [ 49%]
tests/test_lost_seg_tracker.py .............                                   [ 66%]
tests/test_request.py ...                                                      [ 70%]
tests/test_src_handler_acked.py ........                                       [ 80%]
tests/test_src_handler_nak_closure.py .......                                  [ 89%]
tests/test_src_handler_nak_no_closure.py ........                              [100%]

================================= 77 passed in 1.31s =================================
```

Also minor adjusments in other files:
 - Authorize HostFilestore to create parent dirs when creating file
 - Replace absolute imports with relative imports
 - Typing consistency between HostFilestore and VirtualFilestore