### PR TITLE
Potential double read of packet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ ignore = [
     "S101", # Use of assert, should be changed in the future
     "ANN204", # Do not use return typing on __init__, __new__ and __call__ methods
     "E111", # Recommended to be disabled when using the ruff formatter
-    "E114" # Recommended to be disabled when using the ruff formatter
+    "E114", # Recommended to be disabled when using the ruff formatter
+    "SIM105" # Suppress exceptions which is more readable but much slower
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
The example used two variables to represent if a packet was read. There is a potential issue if a packet was received and the next ``queue.get()`` raises Empty. The old packet would be provided to the FSM again. 