### PR TITLE
Disable module index for docs

### DIFF
--- a/docs/api/cfdp.handler.rst
+++ b/docs/api/cfdp.handler.rst
@@ -8,6 +8,7 @@ Package Contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Source Handler Module
 -------------------------------------

--- a/docs/api/cfdp.rst
+++ b/docs/api/cfdp.rst
@@ -8,6 +8,7 @@ Module contents
    :members:
    :undoc-members:
    :show-inheritance:
+   :no-index:
 
 Filestore Module
 -------------------------------


### PR DESCRIPTION
This fixes a lot of warnings thrown by Sphinx due to the new package structure with `__all__` directives.