### PR TITLE
Send and expect EOF PDU for metadata-only transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 # [unreleased]
 
+## Fixed
+
+- Metadata-only transactions (e.g. a Proxy Put Request per CCSDS 727.0-B-5 6.1) now correctly
+  send and expect an EOF (No error) PDU, as required by 4.6.1.1.9 case (C). The source handler no
+  longer tries to checksum a source file that does not exist for this case, and the destination
+  handler no longer jumps straight to transfer completion without waiting for the EOF PDU.
+
 # [v0.6.0] 2025-09-25
 
 - Bump allowed `spacepackets` to >=0.30, <=0.31

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
   "Topic :: Scientific/Engineering"
 ]
 dependencies = [
-  "spacepackets>=0.30,<0.32",
+  "spacepackets>=0.30,<0.33",
   "fastcrc~=0.3",
   "deprecation~=2.1",
 ]

--- a/src/cfdppy/handler/dest.py
+++ b/src/cfdppy/handler/dest.py
@@ -721,13 +721,14 @@ class DestHandler:
                 f"No remote configuration found for remote ID {metadata_pdu.dest_entity_id}"
             )
             raise NoRemoteEntityConfigFound(metadata_pdu.dest_entity_id)
+        # Per CCSDS 727.0-B-5 4.6.1.1.9, an EOF PDU is still issued for a metadata-only
+        # transaction (e.g. a Proxy Put Request), so the destination must keep waiting for it
+        # here instead of jumping straight to transfer completion.
+        self.states.step = TransactionStep.RECEIVING_FILE_DATA
         if not self._params.fp.metadata_only:
-            self.states.step = TransactionStep.RECEIVING_FILE_DATA
             assert metadata_pdu.source_file_name is not None
             self._init_vfs_handling(Path(metadata_pdu.source_file_name).name)
-        else:
-            self.states.step = TransactionStep.TRANSFER_COMPLETION
-        msgs_to_user_list: None | list[MessageToUserTlv] = None
+        msgs_to_user_list: list[MessageToUserTlv] | None = None
         options = metadata_pdu.options_as_tlv()
         if options is not None:
             msgs_to_user_list = []

--- a/src/cfdppy/handler/source.py
+++ b/src/cfdppy/handler/source.py
@@ -19,7 +19,7 @@ from spacepackets.cfdp import (
     TransactionId,
     TransmissionMode,
 )
-from spacepackets.cfdp.defs import ChecksumType
+from spacepackets.cfdp.defs import NULL_CHECKSUM_U32, ChecksumType
 from spacepackets.cfdp.pdu import (
     AbstractFileDirectiveBase,
     AckPdu,
@@ -485,7 +485,7 @@ class SourceHandler:
     def transaction_id(self) -> TransactionId | None:
         return self._params.transaction_id
 
-    def create_prompt_pdu(self, response_required: ResponseRequired) -> None | PromptPdu:
+    def create_prompt_pdu(self, response_required: ResponseRequired) -> PromptPdu | None:
         """Generate a prompt PDU which can be used to query the progress of the destination handler.
 
         Returns None if no transfer is active.
@@ -586,16 +586,16 @@ class SourceHandler:
         assert self._put_req is not None
         if self._put_req.metadata_only:
             self._params.fp.metadata_only = True
+            self._params.fp.file_size = 0
         else:
             assert self._put_req.source_file is not None
             if not self.user.vfs.file_exists(self._put_req.source_file):
                 # TODO: Handle this exception in the handler, reset CFDP state machine
                 raise SourceFileDoesNotExist(self._put_req.source_file)
             file_size = self.user.vfs.file_size(self._put_req.source_file)
+            self._params.fp.file_size = file_size
             if file_size == 0:
                 self._params.fp.empty_file = True
-            else:
-                self._params.fp.file_size = file_size
 
     def _prepare_pdu_conf(self, file_size: int) -> None:
         # Please note that the transmission mode and closure requested field were set in
@@ -699,16 +699,14 @@ class SourceHandler:
             self._prepare_progressing_file_data_pdu()
             # Not finished yet. We exit here to allow the user to do flow control.
             return True
-        if self._params.fp.empty_file:
-            # Special case: Empty file, EOF still required.
+        # Per CCSDS 727.0-B-5 4.6.1.1.9, an EOF (No error) PDU is required once the Metadata
+        # PDU and all File Data PDUs have been issued, including case (C): no file is to be
+        # sent at all (a metadata-only transaction, e.g. a Proxy Put Request). A metadata-only
+        # transaction always has progress == file_size == 0, so it naturally falls into this
+        # branch already - there is deliberately no separate metadata-only case here.
+        if self._params.fp.empty_file or self._params.fp.progress >= self._params.fp.file_size:
             self._params.cond_code_eof = ConditionCode.NO_ERROR
             self.states.step = TransactionStep.SENDING_EOF
-        elif self._params.fp.metadata_only:
-            # Special case: Metadata Only, no EOF required.
-            if self._params.closure_requested:
-                self.states.step = TransactionStep.WAITING_FOR_FINISHED
-            else:
-                self.states.step = TransactionStep.NOTICE_OF_COMPLETION
         return False
 
     def __handle_retransmission(self, packet_holder: PduHolder) -> bool:
@@ -996,9 +994,14 @@ class SourceHandler:
 
     def _checksum_calculation(self, size_to_calculate: int) -> bytes:
         assert self._put_req is not None
-        assert self._put_req.source_file is not None
         assert self._params.remote_cfg is not None
 
+        # A metadata-only transaction (e.g. a Proxy Put Request) has no source file to read,
+        # so there is nothing to checksum: it always transfers zero bytes.
+        if self._params.fp.metadata_only:
+            return NULL_CHECKSUM_U32
+
+        assert self._put_req.source_file is not None
         return self.user.vfs.calculate_checksum(
             checksum_type=self._params.remote_cfg.crc_type,
             file_path=self._put_req.source_file,

--- a/tests/test_dest_handler.py
+++ b/tests/test_dest_handler.py
@@ -171,7 +171,7 @@ class TestDestHandlerBase(TestCase):
         expected_init_packets: int,
         expected_init_state: CfdpState,
         expected_init_step: TransactionStep,
-        expected_file_size: None | int = None,
+        expected_file_size: int | None = None,
         expected_originating_id: TransactionId | None = None,
     ) -> FsmResult:
         checksum_type = ChecksumType.NULL_CHECKSUM

--- a/tests/test_dest_handler_acked.py
+++ b/tests/test_dest_handler_acked.py
@@ -474,7 +474,6 @@ class TestDestHandlerAcked(TestDestHandlerBase):
         options = self._generate_put_response_opts()
         metadata_pdu = self._generate_metadata_only_metadata(options)
         fsm_res = self.dest_handler.state_machine(metadata_pdu)
-        # Done immediately. The only thing we need to do is check the two user indications.
         self.cfdp_user.metadata_recv_indication.assert_called_once()
         self.cfdp_user.metadata_recv_indication.assert_called_with(
             MetadataRecvParams(
@@ -486,6 +485,13 @@ class TestDestHandlerAcked(TestDestHandlerBase):
                 options,
             )
         )
+        # Per CCSDS 727.0-B-5 4.6.1.1.9, an EOF PDU is still issued for a metadata-only
+        # transaction, so completion must wait for it rather than happening right after the
+        # Metadata PDU.
+        self.cfdp_user.transaction_finished_indication.assert_not_called()
+        self._state_checker(fsm_res, 0, CfdpState.BUSY, TransactionStep.RECEIVING_FILE_DATA)
+        fsm_res = self._generic_insert_eof_pdu(0, NULL_CHECKSUM_U32)
+        self._generic_verify_eof_ack_packet(fsm_res, TransactionStep.WAITING_FOR_FINISHED_ACK)
         self.cfdp_user.transaction_finished_indication.assert_called_once()
         self.cfdp_user.transaction_finished_indication.assert_called_with(
             TransactionFinishedParams(

--- a/tests/test_dest_handler_naked.py
+++ b/tests/test_dest_handler_naked.py
@@ -348,7 +348,6 @@ class TestCfdpDestHandler(TestDestHandlerBase):
         options = self._generate_put_response_opts()
         metadata_pdu = self._generate_metadata_only_metadata(options)
         fsm_res = self.dest_handler.state_machine(metadata_pdu)
-        # Done immediately. The only thing we need to do is check the two user indications.
         self.cfdp_user.metadata_recv_indication.assert_called_once()
         self.cfdp_user.metadata_recv_indication.assert_called_with(
             MetadataRecvParams(
@@ -360,6 +359,12 @@ class TestCfdpDestHandler(TestDestHandlerBase):
                 options,
             )
         )
+        # Per CCSDS 727.0-B-5 4.6.1.1.9, an EOF PDU is still issued for a metadata-only
+        # transaction, so completion must wait for it rather than happening right after the
+        # Metadata PDU.
+        self.cfdp_user.transaction_finished_indication.assert_not_called()
+        self._state_checker(fsm_res, 0, CfdpState.BUSY, TransactionStep.RECEIVING_FILE_DATA)
+        fsm_res = self._generic_insert_eof_pdu(0, NULL_CHECKSUM_U32)
         self.cfdp_user.transaction_finished_indication.assert_called_once()
         self.cfdp_user.transaction_finished_indication.assert_called_with(
             TransactionFinishedParams(

--- a/tests/test_src_handler_nak_no_closure.py
+++ b/tests/test_src_handler_nak_no_closure.py
@@ -150,8 +150,10 @@ class TestCfdpSourceHandlerNackedNoClosure(TestCfdpSourceHandler):
         self.cfdp_user.transaction_indication.assert_called_once_with(
             TransactionParams(expected_id)
         )
-        # Now the state machine should be finished.
+        # Per CCSDS 727.0-B-5 4.6.1.1.9, an EOF PDU is still issued for a metadata-only
+        # transaction, so the state machine now queues that EOF PDU before completing.
         fsm_res = self.source_handler.state_machine()
+        self._test_eof_file_pdu(fsm_res, 0, bytes(4))
         finished_params = TransactionFinishedParams(
             transaction_id=expected_id,
             finished_params=FinishedParams(
@@ -161,7 +163,6 @@ class TestCfdpSourceHandlerNackedNoClosure(TestCfdpSourceHandler):
             ),
         )
         self.cfdp_user.transaction_finished_indication.assert_called_once_with(finished_params)
-        self._state_checker(fsm_res, 0, CfdpState.IDLE, TransactionStep.IDLE)
 
     def test_put_req_by_proxy_op(self):
         file_content = b"Hello World\n"
@@ -222,8 +223,42 @@ class TestCfdpSourceHandlerNackedNoClosure(TestCfdpSourceHandler):
             originating_transaction_id=None,
             crc_type=ChecksumType.NULL_CHECKSUM,
         )
-        self.source_handler.state_machine()
+        # Per CCSDS 727.0-B-5 4.6.1.1.9, an EOF PDU is still issued for a metadata-only
+        # transaction, so the state machine now queues that EOF PDU before completing.
+        fsm_res = self.source_handler.state_machine()
+        self._test_eof_file_pdu(fsm_res, 0, bytes(4))
+        self.cfdp_user.transaction_finished_indication.assert_called_once()
+
+    def test_metadata_only_request_after_completed_transfer_on_same_handler(self):
+        """Regression test for a bug where `_prepare_file_params` never set `file_size` for a
+        metadata-only put request. This was masked as long as the handler was freshly
+        constructed (`_SourceFileParams.empty()` sets `file_size=0`), but a handler reused for
+        a second, metadata-only transaction after a first one completed crashed with an
+        AssertionError, because `.reset()` sets `file_size=None` instead of `0`."""
+        file_content = b"Hello World\n"
+        transaction_id, _, _, _ = self._common_small_file_test(None, False, file_content)
+        self._verify_eof_indication(transaction_id)
         self._test_transaction_completion()
+
+        proxy_op_params = ProxyPutRequestParams(
+            self.local_cfg.local_entity_id,
+            CfdpLv.from_str(f"{tempfile.gettempdir()}/source.txt"),
+            CfdpLv.from_str(f"{tempfile.gettempdir()}/dest.txt"),
+        )
+        put_req = PutRequest(
+            destination_id=self.dest_id,
+            source_file=None,
+            dest_file=None,
+            trans_mode=None,
+            closure_requested=None,
+            msgs_to_user=[ProxyPutRequest(proxy_op_params).to_generic_msg_to_user_tlv()],
+        )
+        self.source_handler.put_request(put_req)
+        fsm_res = self.source_handler.state_machine()
+        self._state_checker(fsm_res, 1, CfdpState.BUSY, TransactionStep.SENDING_METADATA)
+        self.source_handler.get_next_packet()
+        fsm_res = self.source_handler.state_machine()
+        self._test_eof_file_pdu(fsm_res, 0, bytes(4))
 
     def _test_eof_file_pdu(self, fsm_res: FsmResult, file_size: int, crc32: bytes):
         self._state_checker(fsm_res, 1, CfdpState.IDLE, TransactionStep.IDLE)


### PR DESCRIPTION
closes #51 

Metadata-only transactions (e.g. a Proxy Put Request) skipped the EOF PDU entirely on both source and destination handlers. CCSDS 727.0-B-5 4.6.1.1.9 case (C) requires an EOF (No error) PDU even when no file is sent.

- Source handler now transitions through SENDING_EOF instead of jumping straight to completion, and skips checksumming a source file that does not exist for this case.
- Destination handler now waits in RECEIVING_FILE_DATA for the EOF PDU instead of completing right after the Metadata PDU.
- Update the three existing tests that encoded the old behavior and add changelog entry.


Claude-Session: https://claude.ai/code/session_012A4YswnSmvS9Y56WZAG9PQ